### PR TITLE
[WIP] Add Sunbeam TLS Vault Feature

### DIFF
--- a/sunbeam-python/sunbeam/features/tls/README.md
+++ b/sunbeam-python/sunbeam/features/tls/README.md
@@ -1,47 +1,10 @@
-# TLS CA feature (Manual TLS Certificate Operator)
+# Sunbeam TLS Feature
 
 This feature enables user to provide TLS certificates obtained through manual process. The certificates can be applied on public and internal traefik instances.
 
 ## Installation
 
-To enable the TLS CA feature, you need an already bootstraped Sunbeam instance. Then, you can install the feature with:
+Sunbeam supports 2 different methods to enable TLS CA:
 
-```bash
-sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain>
-```
-
-By default the TLS Certificate charm integrates with public traefik instances.
-To integrate with internal traefik instances as well, install the feature with:
-
-```bash
-sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal
-```
-
-To integrate with internal and rgw traefik instances as well, install the feature with:
-
-```bash
-sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal --endpoint rgw
-```
-
-## Configure
-
-To apply tls certificate on the traefik instances, run the following command:
-
-```bash
-sunbeam tls ca unit_certs
-```
-
-The above command will prompt the user for TLS Certificate for each traefik unit.
-
-## Contents
-
-This feature will install the following services:
-- Manual TLS Certificate operator: [charm](https://github.com/canonical/manual-tls-certificates-operator)
-
-## Removal
-
-To remove the feature, run:
-
-```bash
-sunbeam disable tls ca
-```
+- [TLS CA via Manual TLS Certificate Operator](./VaultTLS.md)
+- [Vault TLS](./VaultTLS.md)

--- a/sunbeam-python/sunbeam/features/tls/TLSCA.md
+++ b/sunbeam-python/sunbeam/features/tls/TLSCA.md
@@ -1,0 +1,47 @@
+# TLS CA feature (Manual TLS Certificate Operator)
+
+This feature enables user to provide TLS certificates obtained through manual process. The certificates can be applied on public and internal traefik instances.
+
+## Installation
+
+To enable the TLS CA feature, you need an already bootstraped Sunbeam instance. Then, you can install the feature with:
+
+```bash
+sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain>
+```
+
+By default the TLS Certificate charm integrates with public traefik instances.
+To integrate with internal traefik instances as well, install the feature with:
+
+```bash
+sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal
+```
+
+To integrate with internal and rgw traefik instances as well, install the feature with:
+
+```bash
+sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal --endpoint rgw
+```
+
+## Configure
+
+To apply tls certificate on the traefik instances, run the following command:
+
+```bash
+sunbeam tls ca unit_certs
+```
+
+The above command will prompt the user for TLS Certificate for each traefik unit.
+
+## Contents
+
+This feature will install the following services:
+- Manual TLS Certificate operator: [charm](https://github.com/canonical/manual-tls-certificates-operator)
+
+## Removal
+
+To remove the feature, run:
+
+```bash
+sunbeam disable tls ca
+```

--- a/sunbeam-python/sunbeam/features/tls/VaultTLS.md
+++ b/sunbeam-python/sunbeam/features/tls/VaultTLS.md
@@ -1,0 +1,53 @@
+# TLS Vault feature
+
+This feature enables user to provide TLS certificates obtained through manual process. The certificates can be applied on public and internal traefik instances.
+
+## Prerequisites
+
+This feature requires the Vault feature enabled in sunbeam. For this, follow this [guide](https://canonical-openstack.readthedocs-hosted.com/en/latest/how-to/features/vault/).
+
+## Installation
+
+To enable the TLS Vault feature, you need an already bootstraped Sunbeam instance. Then, you can install the feature with:
+
+```bash
+sunbeam enable tls vault --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain>
+```
+
+**NOTE**: The certificate needs to be created as a CA certificate. This can be done by adding to the certificate the `x509 Extension -> CA:TRUE`.
+
+By default the TLS Certificate charm integrates with public traefik instances.
+To integrate with internal traefik instances as well, install the feature with:
+
+```bash
+sunbeam enable tls vault --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal
+```
+
+To integrate with internal and rgw traefik instances as well, install the feature with:
+
+```bash
+sunbeam enable tls vault --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal --endpoint rgw
+```
+
+## Configure
+
+To apply tls certificate on the traefik instances, run the following command:
+
+```bash
+sunbeam tls vault unit_certs
+```
+
+The above command will prompt the user for TLS Certificate for each traefik unit.
+
+## Contents
+
+This feature will require the following services:
+- Vault-K8s: [charm](https://github.com/canonical/vault-k8s-operator)
+
+## Removal
+
+To remove the feature, run:
+
+```bash
+sunbeam disable tls vault
+```

--- a/sunbeam-python/sunbeam/features/tls/feature.py
+++ b/sunbeam-python/sunbeam/features/tls/feature.py
@@ -1,3 +1,4 @@
 # SPDX-FileCopyrightText: 2024 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 from .ca import CaTlsFeature  # noqa: F401
+from .vault import VaultTlsFeature  # noqa: F401


### PR DESCRIPTION
This PR introduces the TLS Vault feature, which allows the operator to configure Vault (Vault-k8s charm) as an Intermediary CA.

*NOTE:* This PR should not be merged until the following steps are finished:
- Manual-TLS-Certificates has a new stable release with the features from `1/edge`
- The `common_name` configuration for Vault and `external_hostname` for Traefik endpoints are properly defined

*NOTE 2*: This PR adds breaking changes unless the [PR](https://github.com/canonical/sunbeam-terraform/pull/108) from sunbeam-terraform is merge